### PR TITLE
Rake DSL deprecation warning

### DIFF
--- a/lib/single_test.rb
+++ b/lib/single_test.rb
@@ -1,6 +1,7 @@
 require 'rake'
 
 module SingleTest
+  include Rake::DSL
   extend self
   CMD_LINE_MATCHER = /^(spec|test)\:.*(\:.*)?$/
 


### PR DESCRIPTION
With rake 0.9.2, a deprecation message has been popping up:

```
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
WARNING: DSL method Module#sh called at /opt/local/lib/ruby/gems/1.8/gems/single_test-0.4.0/lib/tasks/../single_test.rb:78:in `run_test'
```

This should take care of it.
