### PR TITLE
Support for test class names.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,7 @@ Authors
 ### [Contributors](http://github.com/grosser/single_test/contributors)
  - [Ian Young](https://github.com/iangreenleaf)
  - [Lorrin Nelson](https://github.com/lorrin)
+ - [Jason King](https://github.com/smathy)
 
 [Michael Grosser](http://grosser.it)<br/>
 michael@grosser.it<br/>

--- a/lib/single_test.rb
+++ b/lib/single_test.rb
@@ -1,10 +1,10 @@
 require 'rake'
-require 'active_support/inflector'
+require 'single_test/inflector'
 
 module SingleTest
   extend self
 
-  include ActiveSupport::Inflector
+  extend Inflector
   include Rake::DSL if defined? Rake::DSL # 0.8.7 does not have it
   CMD_LINE_MATCHER = /^(spec|test)\:.*(\:.*)?$/
 

--- a/lib/single_test/inflector.rb
+++ b/lib/single_test/inflector.rb
@@ -1,0 +1,14 @@
+# copied from Rails - so we're not dependent
+module SingleTest
+  module Inflector
+    def underscore(camel_cased_word)
+      word = camel_cased_word.to_s.dup
+      word.gsub!(/::/, '/')
+      word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      word.tr!("-", "_")
+      word.downcase!
+      word
+    end
+  end
+end

--- a/single_test.gemspec
+++ b/single_test.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{single_test}
-  s.version = "0.4.1"
+  s.version = "0.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Michael Grosser"]

--- a/spec/single_test_spec.rb
+++ b/spec/single_test_spec.rb
@@ -34,6 +34,21 @@ describe SingleTest do
     it "does not split test name further" do
       SingleTest.parse_cli('test:something:else:oh:no')[2].should == 'else:oh:no'
     end
+
+    it "parses ClassNames" do
+      SingleTest.parse_cli('test:ClassNames')[1].should == 'class_names'
+    end
+
+    it "parses ClassNames::WithNamespaces" do
+      SingleTest.parse_cli('test:ClassNames::WithNamespaces')[1].should == 'class_names/with_namespaces'
+    end
+
+    it "doesn't confuse :s with ::s" do
+      parsed = SingleTest.parse_cli('test:ClassNames::WithNamespaces:foobar')
+      parsed[0].should == 'test'
+      parsed[1].should == 'class_names/with_namespaces'
+      parsed[2].should == 'foobar'
+    end
   end
 
   describe :find_test_file do


### PR DESCRIPTION
I kept finding myself trying to run tests by copying the test class name straight from my [Turn](https://github.com/TwP/turn) output or from within the file itself.  Ie.

```
rake test:Foo::Bar::OinkTest
```

Felt like it _should_ work, so I added the small extra piece to make it work.
